### PR TITLE
Fixes #3917 - Create STAR_GD-FF CTA Line.txt

### DIFF
--- a/Misc/STAR_GD-FF CTA Line.txt
+++ b/Misc/STAR_GD-FF CTA Line.txt
@@ -1,0 +1,2 @@
+;GD-FF Delegated Airspace Line
+GD-FF CTA Line			   N051.31.01.426 W003.02.59.829 N051.35.29.428 W002.42.10.630


### PR DESCRIPTION
Fixes #3917

# Summary of changes

A line to delineate two areas of delegated airspace was missing - this draws this line to separate these.   A vMATS update will be issued in version 2021-12.

# Screenshots (if necessary)

Orange line shown below (added as SID for screenshot purpose to highlight - added as STAR for practical purpose):
![image](https://user-images.githubusercontent.com/24749537/144121843-40df050d-3fea-4851-bc87-5f2f20fad9c7.png)

Diagram from vMATS update:

![CTA Line2](https://user-images.githubusercontent.com/24749537/144121960-eddb1e16-1763-4828-9e0e-8c97391ab999.png)
